### PR TITLE
Addition of search and add feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         </a>
         <a id="author" class="floating" href="https://sarthak-sehgal.github.io" target="_blank">
             <img src="heart.png" alt="star"/>
-            Made by Sarthak Sehgal
+            Made by Sarthak Sehgal, Search feature by Pratham Gupta
         </a>
         <div id="author1" class="floating" href="#">
             <img src="social.png" alt="star"/>            
@@ -98,5 +98,14 @@
     crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.6-rc.0/js/select2.min.js"></script>
     <script src="main.js"></script>
+    <div>
+        <form id="messageForm">
+            Search Course: <input type="text" id="inputMessage" name="message" placeholder="BITS F111">
+            <button type="submit">Search!</button>
+        </form>
+    </div>
+
+    <form id="choices">
+    </form>
 </body>
 </html>

--- a/main.css
+++ b/main.css
@@ -161,7 +161,7 @@ html, body {
     color: #fff;
     font-weight: bold;
     position: fixed;
-    left: 10px;
+    right: 10px;
     bottom: 10px;
 }
 
@@ -209,6 +209,10 @@ html, body {
     text-align: center;
     color: #fff;
     font-weight: bold;
+}
+
+#choices {
+    text-align: left;
 }
 
 @media all and (max-width: 1000px) {

--- a/main.js
+++ b/main.js
@@ -1,4 +1,7 @@
 document.addEventListener("DOMContentLoaded", function () {
+    var globalDays = [];
+    var globalHours = [];
+
     const HOURS = [
         "8:00 - 9:00",
         "9:00 - 10:00",
@@ -47,7 +50,7 @@ document.addEventListener("DOMContentLoaded", function () {
     let BG_USED = new Array(BACKGROUNDS.length);
     for(let i=0; i<BG_USED.length; i++)
         BG_USED[i] = 0;
-
+ 
     const BG_OPACITY = 60;
 
     let timetable = document.getElementById("timetable");
@@ -82,7 +85,14 @@ document.addEventListener("DOMContentLoaded", function () {
         let classroom = document.getElementById("classroom").value;
         let section = document.getElementById("section").value;
         let days = $("#days").select2('val');
+
+        if (days.length === 0)
+            days = globalDays; 
+                
         let hours = $("#hours").select2('val');
+
+        if (hours.length === 0)
+            hours = globalHours;
 
         if(title.trim() && days.length>0 && hours.length>0 && section.trim()) {
             let random = Math.floor(Math.random() * (BACKGROUNDS.length));
@@ -207,7 +217,170 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         return 1;
     }
+    const $messageform = document.getElementById("messageForm");
+    const $messageFormInput = $messageform.querySelector("input");
+    const $messageFormButton = $messageform.querySelector("button");
 
+    const $choicesForm = document.getElementById("choices");
+
+    $choicesForm.addEventListener("submit", (e) => {
+        document.getElementById("error").style.display = 'none';
+        e.preventDefault();
+        const selection = e.target.elements.slot.value;
+
+        var contents = selection.split(", ")
+
+        document.getElementById("section").value = contents[0] + " " + contents[3];
+        document.getElementById("course-title").value = document.getElementById("addAfterSearch").value;
+        var days = contents[1].split(" ");
+        days.forEach(convert)
+        
+        function convert(item, index, arr) {
+            if (item === "M")
+                arr[index] = "1";
+            if (item === "T")
+                arr[index] = "2";
+            if (item === "W")
+                arr[index] = "3";
+            if (item === "Th")
+                arr[index] = "4";
+            if (item === "F")
+                arr[index] = "5";
+            if (item === "S")
+                arr[index] = "6";      
+        }
+        
+        if (days[days.length - 1] === "")
+            days.pop()
+        globalDays = days;
+        var hours = contents[2].split("");
+
+        if (hours[hours.length - 1] === "0") {
+            hours.pop()
+            hours[hours.length - 1] ="10"
+        }
+        globalHours = hours;
+        
+        document.getElementById("add-btn").click();
+    })
+
+    $messageform.addEventListener("submit", async (e) => {
+        
+        e.preventDefault();
+        $messageFormButton.setAttribute("disabled", "disabled");
+        $messageFormButton.innerHTML="Loading..."
+
+        var radio_home = document.getElementById("choices");
+        radio_home.innerHTML = "";
+
+        const url=`https://timetablevisualiser-api.herokuapp.com/CourseData?course_number=${e.target.elements.message.value}`
+                
+        await fetch(url).then((res) => {
+            const result = res.json().then((a) => {
+                var para = document.createElement("p");
+                var node = document.createTextNode(a.Course_Number);
+                para.appendChild(node);
+
+                var element = document.getElementById("choices");
+                element.appendChild(para);
+
+                if (a.lectures.length === 0) {
+                    var para = document.createElement("p");
+                    var node = document.createTextNode("Invalid Course Name");
+                    para.appendChild(node);
+
+                    var element = document.getElementById("choices");
+                    element.appendChild(para);
+                }
+
+                else {
+                    var para = document.createElement("p");
+                    var node = document.createTextNode("Lectures");
+                    para.appendChild(node);
+                    var element = document.getElementById("choices");
+
+                    var lineBreak = document.createElement("BR");
+                    radio_home.appendChild(lineBreak);
+                    element.appendChild(para);
+                }
+
+                for (var i in a.lectures) {
+                    var slot = makeRadioButton("slot", a.lectures[i], a.lectures[i]);
+                    var lineBreak = document.createElement("BR");
+                    radio_home.appendChild(slot);
+                    radio_home.appendChild(lineBreak);
+                }
+
+                if (a.practicals.length) {
+                    var para = document.createElement("p");
+                    var node = document.createTextNode("Practicals");
+                    para.appendChild(node);
+                    var element = document.getElementById("choices");
+
+                    var lineBreak = document.createElement("BR");
+                    radio_home.appendChild(lineBreak);
+                    element.appendChild(para);
+                }
+
+                for (var i in a.practicals) {
+                    var slot = makeRadioButton("slot", a.practicals[i], a.practicals[i]);
+                    var lineBreak = document.createElement("BR");
+                    radio_home.appendChild(slot);
+                    radio_home.appendChild(lineBreak);
+                }
+
+                if (a.tutorials.length) {
+                    var para = document.createElement("p");
+                    var node = document.createTextNode("Tutorials");
+                    para.appendChild(node);
+                    var element = document.getElementById("choices");
+
+                    var lineBreak = document.createElement("BR");
+                    radio_home.appendChild(lineBreak);
+                    element.appendChild(para);
+                }
+
+                for (var i in a.tutorials) {
+                    var slot = makeRadioButton("slot", a.tutorials[i], a.tutorials[i]);
+                    var lineBreak = document.createElement("BR");
+                    radio_home.appendChild(slot);
+                    radio_home.appendChild(lineBreak);
+                }
+                var newButton = document.createElement("BUTTON");
+                var buttonText = document.createTextNode("Add to Timetable");
+                newButton.setAttribute("id", "addAfterSearch");
+                newButton.setAttribute("value", a.Course_Number);
+                newButton.appendChild(buttonText);
+                radio_home.appendChild(newButton);
+            });
+        }).catch((e) => {
+            var para = document.createElement("p");
+            var node = document.createTextNode("Can't fetch details at the moment.");
+            para.appendChild(node);
+            var element = document.getElementById("choices");
+
+            var lineBreak = document.createElement("BR");
+            radio_home.appendChild(lineBreak);
+            element.appendChild(para);
+        })
+
+        function makeRadioButton(name, value, text) {
+            var label = document.createElement("label");
+            var radio = document.createElement("input");
+            radio.type = "radio";
+            radio.name = name;
+            radio.value = value;
+
+            label.appendChild(radio);
+
+            label.appendChild(document.createTextNode(text));
+            return label;
+        }  
+        $messageFormButton.removeAttribute("disabled");
+        $messageFormButton.innerHTML = "Search!";
+        var scrollingElement = (document.scrollingElement || document.body);
+        scrollingElement.scrollTop = scrollingElement.scrollHeight;
+    });
 });
 
 $(document).ready(function() {


### PR DESCRIPTION
I have added a search and add feature to the visualiser (at the bottom). Users can simply type in a course title like "CS F111" or "ME F110" and the website shows a list of all available slots for the course which can selected from a radio button and get added directly to the timetable. I believe this feature will greatly enhance user experience by saving a lot of time spent looking at the timetable booklet. The feature fetches the data from a django based website hosted on heroku which reads the timetable pdf which we recieve after it is converted to excel using tool available online.

The fork is published at https://pratham1002.github.io/timetable-visualizer/
The source for the backend is available at https://github.com/pratham1002/time-table-api

I hope this would be a valueable contribution.

Regards,
Pratham Neeraj Gupta
2019A7PS0051P

email: f20190051@pilani.bits-pilani.ac.in